### PR TITLE
feat(shared-utils): /react 서브 익스포트 추가 + useDebouncedCallback 훅

### DIFF
--- a/.changeset/shared-utils-react-sub-export.md
+++ b/.changeset/shared-utils-react-sub-export.md
@@ -1,0 +1,5 @@
+---
+"@coldsurf/shared-utils": minor
+---
+
+`/react` 서브 익스포트 추가 — `useDebouncedCallback` (콜백 debounce React 훅)

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -25,17 +25,18 @@
       "import": "./dist/next/index.js",
       "require": "./dist/next/index.cjs",
       "types": "./next/index.d.ts"
+    },
+    "./react": {
+      "import": "./dist/react/index.js",
+      "require": "./dist/react/index.cjs",
+      "types": "./react/index.d.ts"
     }
   },
   "main": "dist/index.js",
   "type": "module",
   "source": "src/",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "next",
-    "package.json"
-  ],
+  "files": ["dist", "next", "react", "package.json"],
   "scripts": {
     "build": "pnpm build:core",
     "build:core": "tsdown",
@@ -54,8 +55,10 @@
     "slugify": "1.6.6"
   },
   "devDependencies": {
+    "@types/react": "^19.1.0",
     "jwt-decode": "^4.0.0",
     "prettier": "*",
+    "react": "^19.1.0",
     "schema-dts": "1.1.2",
     "tsdown": "^0.11.9",
     "vitest": "^4.0.18",
@@ -63,11 +66,15 @@
   },
   "peerDependencies": {
     "jwt-decode": "^4.0.0",
+    "react": "^18.0.0 || ^19.0.0",
     "schema-dts": "^1.1.2",
     "zod": "^3.23.8"
   },
   "peerDependenciesMeta": {
     "jwt-decode": {
+      "optional": true
+    },
+    "react": {
       "optional": true
     },
     "schema-dts": {

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -5,7 +5,7 @@
     "email": "imcoldsurf@gmail.com",
     "url": "https://coldsurf.io"
   },
-  "version": "1.1.16",
+  "version": "1.2.0-alpha.0",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/coldsurfers/surfers-common/issues"

--- a/packages/shared-utils/react/index.d.ts
+++ b/packages/shared-utils/react/index.d.ts
@@ -1,0 +1,7 @@
+// This file is needed for projects that have `moduleResolution` set to `node`
+// in their tsconfig.json to be able to `import {} from '@coldsurf/shared-utils/react'`.
+// Other module resolution strategies will look for the `exports` in `package.json`,
+// but with `node`, TypeScript will look for a .d.ts file with that name at the
+// root of the package.
+
+export * from '../dist/react';

--- a/packages/shared-utils/src/react/index.ts
+++ b/packages/shared-utils/src/react/index.ts
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+// biome-ignore lint/suspicious/noExplicitAny: generic callback signature
+export function useDebouncedCallback<T extends (...args: any[]) => void>(
+  fn: T,
+  delay: number
+): (...args: Parameters<T>) => void {
+  const fnRef = useRef(fn);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    fnRef.current = fn;
+  });
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => fnRef.current(...args), delay);
+    },
+    [delay]
+  );
+}

--- a/packages/shared-utils/tsconfig.json
+++ b/packages/shared-utils/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "baseUrl": ".",
     "paths": {
+      "react": ["./node_modules/@types/react"],
       "@/": ["./src"],
       "@/*": ["./src/*"]
     }

--- a/packages/shared-utils/tsdown.config.ts
+++ b/packages/shared-utils/tsdown.config.ts
@@ -28,4 +28,11 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     ...commonConfigs,
   },
+  {
+    entry: {
+      'react/index': 'src/react/index.ts',
+    },
+    format: ['esm', 'cjs'],
+    ...commonConfigs,
+  },
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,12 +72,18 @@ importers:
         specifier: 1.6.6
         version: 1.6.6
     devDependencies:
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.1.0
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
       prettier:
         specifier: '*'
         version: 3.8.0
+      react:
+        specifier: ^19.1.0
+        version: 19.1.4
       schema-dts:
         specifier: 1.1.2
         version: 1.1.2(typescript@5.8.3)
@@ -543,7 +549,6 @@ packages:
 
   '@evilmartians/lefthook@1.13.6':
     resolution: {integrity: sha512-79vplrUBWL4Fkt59YkEBdSpqBVhNrY8t5+jEp+wX5QbsmbQLcSULqwS7FmbNRyECa2LWMrUWpe6ENIfNwB4jiw==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -3616,7 +3621,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.12.0)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4563,7 +4568,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.12.0)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)

--- a/specs/shared-utils/react-subpath.md
+++ b/specs/shared-utils/react-subpath.md
@@ -69,7 +69,7 @@ packages/shared-utils/
 
 - [x] `pnpm build` 빌드 성공
 - [x] `pnpm check:type` 타입 에러 없음
-- [ ] `billets-admin`의 `libs/hooks/use-debounced-callback.ts` →
+- [x] `billets-admin`의 `libs/hooks/use-debounced-callback.ts` 삭제 →
       `@coldsurf/shared-utils/react`로 교체
 
 ---

--- a/specs/shared-utils/react-subpath.md
+++ b/specs/shared-utils/react-subpath.md
@@ -1,0 +1,85 @@
+# shared-utils: react subpath 추가 + useDebouncedCallback
+
+## 목표
+
+`@coldsurf/shared-utils/react` subpath를 신규 추가하고,
+콜백 debounce 훅 `useDebouncedCallback`을 제공한다.
+
+기존 `./next` subpath 패턴을 그대로 따른다.
+
+## 현재 구조
+
+```
+packages/shared-utils/
+  src/
+    index.ts        — 메인 엔트리
+    next/index.ts   — Next.js 전용 유틸
+  next/
+    index.d.ts      — moduleResolution: node 폴백 타입
+  tsdown.config.ts  — index + next/index 빌드
+  package.json
+    exports: { ".", "./next" }
+    peerDependencies: { jwt-decode, schema-dts, zod }
+```
+
+## 목표 구조
+
+```
+packages/shared-utils/
+  src/
+    react/
+      index.ts          — useDebouncedCallback 훅
+  react/
+    index.d.ts          — moduleResolution: node 폴백 타입
+```
+
+## 체크리스트
+
+### 소스
+
+- [x] `src/react/index.ts` 생성
+  - `useDebouncedCallback<T>(fn: T, delay: number)` 구현
+  - `fnRef`로 stale closure 방지
+  - `'use client'` 미사용 — RSC 외 환경에서 무의미, 소비자가 경계 관리
+
+### 타입 폴백
+
+- [x] `react/index.d.ts` 생성
+  - `export * from '../dist/react'`
+  - `moduleResolution: node` 환경 대응
+
+### package.json 수정
+
+- [x] `exports`에 `"./react"` 추가
+- [x] `files`에 `"react"` 추가
+- [x] `peerDependencies`에 `react: "^18.0.0 || ^19.0.0"` 추가 (optional)
+- [x] `peerDependenciesMeta`에 `react: { optional: true }` 추가
+- [x] `devDependencies`에 `react: ^19.1.0`, `@types/react: ^19.1.0` 추가
+
+### tsdown.config.ts 수정
+
+- [x] `react/index` 엔트리 추가
+
+### tsconfig.json 수정
+
+- [x] `paths`에 `"react": ["./node_modules/@types/react"]` 추가
+  - `baseUrl: "."` + 로컬 `react/` 폴더 충돌로 인해 `import 'react'`가 로컬 index.d.ts로 잡히는 문제 해결
+
+### 검증
+
+- [x] `pnpm build` 빌드 성공
+- [x] `pnpm check:type` 타입 에러 없음
+- [ ] `billets-admin`의 `libs/hooks/use-debounced-callback.ts` →
+      `@coldsurf/shared-utils/react`로 교체
+
+---
+
+## 변경 범위 요약
+
+| 파일 | 변경 |
+|------|------|
+| `src/react/index.ts` | 신규 — useDebouncedCallback |
+| `react/index.d.ts` | 신규 — 타입 폴백 |
+| `package.json` | exports / files / peerDeps 수정 |
+| `tsdown.config.ts` | react/index 엔트리 추가 |
+| `apps/billets-admin/libs/hooks/use-debounced-callback.ts` | 삭제 후 패키지 import로 교체 |


### PR DESCRIPTION
## 요약

- `@coldsurf/shared-utils/react` 서브 익스포트 신규 추가
- `useDebouncedCallback<T>(fn, delay)` React 훅 구현
- `./next` 서브 익스포트 패턴 동일하게 적용

## 변경 내용

- `src/react/index.ts` — `useDebouncedCallback` 구현 (`fnRef`로 stale closure 방지)
- `react/index.d.ts` — `moduleResolution: node` 환경 폴백 타입
- `package.json` — exports / files / peerDeps(`react` optional) / devDeps 업데이트
- `tsdown.config.ts` — `react/index` 빌드 엔트리 추가
- `tsconfig.json` — `paths`에 `react` 명시 (로컬 `react/` 폴더와 충돌 해결)

## 사용법

```ts
import { useDebouncedCallback } from '@coldsurf/shared-utils/react'

const scheduleSave = useDebouncedCallback((data) => save(data), 3000)
```

## 테스트 플랜

- [x] `pnpm --filter @coldsurf/shared-utils build` 빌드 성공 확인
- [x] `pnpm --filter @coldsurf/shared-utils check:type` 타입 에러 없음 확인
- [x] 소비 앱에서 `@coldsurf/shared-utils/react` import 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)